### PR TITLE
DEV-11590 Replace use of deprecated transform with inline XPath

### DIFF
--- a/src/operations-hotspot.json
+++ b/src/operations-hotspot.json
@@ -110,20 +110,9 @@
 		"label": "Area",
 		"getStateSteps": [
 			{
-				"type": "transform/setContextNodeIdToSelectionAncestor",
-				"data": {
-					"selectionAncestorNodeSpec": "self::lcHotspot2"
-				}
-			},
-			{
-				"type": "transform/setContextNodeIdToFirstMatchingNodeFromContextNode",
-				"data": {
-					"xPathQuery": "./lcHotspotMap2"
-				}
-			},
-			{
 				"type": "operation/append-structure",
 				"data": {
+					"contextNodeId": "fonto:selection-common-ancestor()/ancestor-or-self::lcHotspot2/lcHotspotMap2[1]",
 					"childNodeStructure": [
 						"lcArea2",
 						["lcAreaShape2", "TEST"],
@@ -134,19 +123,10 @@
 		],
 		"steps": [
 			{
-				"type": "transform/setContextNodeIdToSelectionAncestor",
+				"type": "operation/:_open-shape-editor-modal-for-insert--lcHotspot2",
 				"data": {
-					"selectionAncestorNodeSpec": "self::lcHotspot2"
+					"contextNodeId": "fonto:selection-common-ancestor()/ancestor-or-self::lcHotspot2/lcHotspotMap2[1]"
 				}
-			},
-			{
-				"type": "transform/setContextNodeIdToFirstMatchingNodeFromContextNode",
-				"data": {
-					"xPathQuery": "./lcHotspotMap2"
-				}
-			},
-			{
-				"type": "operation/:_open-shape-editor-modal-for-insert--lcHotspot2"
 			},
 			{
 				"type": "operation/append-structure",


### PR DESCRIPTION
The `setContextNodeIdToFirstMatchingNodeFromContextNode` transform will likely be deprecated in 7.16.0. This replaces the only two occurrences of this transform in the DITA example config with equivalent inline XPath.